### PR TITLE
Fix DEP_WEBPACK_COMPILATION_ASSETS warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
  *
  */
 
+const fs = require('fs');
+const path = require('node:path');
 const ConstDependency = require('webpack/lib/dependencies/ConstDependency')
 const NullFactory = require('webpack/lib/NullFactory')
 
@@ -64,15 +66,9 @@ class DrupalTranslationsWebpackPlugin {
 
       const content = fileOutput(functionCallsString)
 
-      // Attach our translations file to the compilation assets.
-      compilation.assets[output] = {
-        source: () => {
-          return content
-        },
-        size: () => {
-          return content.length
-        }
-      }
+      // Write our translation file.
+      const outputPath = compilation.compiler.outputPath
+      fs.writeFileSync(path.join(outputPath, output), content);
 
       // Done!
       callback()


### PR DESCRIPTION
Webpack 5 prints a warning (DEP_WEBPACK_COMPILATION_ASSETS) when assets are modified after being "sealed".

I initially tried using an earlier hook, but then the translation file was getting processed by Terser which we don't want since then Drupal could have issues finding the translation calls.

This patch writes the translation file directly to the output directory during the emit hook, bypassing asset modification and any additional processing by other plugins like Terser.